### PR TITLE
Merging log files to prevent appending app id.

### DIFF
--- a/pm2/templates/default/application.json.erb
+++ b/pm2/templates/default/application.json.erb
@@ -6,6 +6,7 @@
             "exec_mode"   : "fork_mode",
             "script"      : "start.js",
             "cwd"         : "/srv/www/app/current/",
+            "merge_logs"  : true,
             "error_file"  : "/srv/www/app/current/log/out.log",
             "out_file"    : "/srv/www/app/current/log/out.log",
             "env"         : <%= node[:deploy]['app'][:environment_variables].to_json %>


### PR DESCRIPTION
pm2 appends the app id onto the log file name specified in the config. This is causing the cloudwatch log monitor to fail because the file is named differently. The merge_logs option should prevent this and correct the issue with cloudwatch logs.