### PR TITLE
adding logrotate to hourly

### DIFF
--- a/logs/recipes/install.rb
+++ b/logs/recipes/install.rb
@@ -25,3 +25,16 @@ file '/etc/logrotate.d/newrelic' do
         copytruncate
         }'
 end
+
+file '/etc/cron.hourly/logrotate' do
+ mode 0755
+ owner 'root'
+ group 'root'
+ content '#!/bin/sh
+  /usr/sbin/logrotate /etc/logrotate.conf >/dev/null 2>&1
+  EXITVALUE=$?
+  if [ $EXITVALUE != 0 ]; then
+      /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+  fi
+  exit 0'
+end


### PR DESCRIPTION
file size rotation works, but logrotate only checks daily for the file size. Still not good enough. This adds the logrotate command to the hourly cron so newrelic logs will be checked for logrotate conditions hourly.