### PR TITLE
Resource ordering

### DIFF
--- a/appserver/recipes/deploy.rb
+++ b/appserver/recipes/deploy.rb
@@ -17,22 +17,7 @@ else
     env_var = env_var + '"CONTAINER":"unknown"'
 end
 
-directory '/tmp/.ssh' do
-  owner 'root'
-  group 'root'
-  mode '0770'
-  recursive true
-  action :create
-  notifies :create, 'template[/tmp/.ssh/chef_ssh_deploy_wrapper.sh]', :immediately
-end
-
-template "/tmp/.ssh/chef_ssh_deploy_wrapper.sh" do
-  source "chef_ssh_deploy_wrapper.sh.erb"
-  owner 'root'
-  mode 0770
-  action :nothing
-  notifies :sync, "git[/srv/www/app/releases/#{release}]", :immediately
-end
+include_recipe 'appserver::deploy_wrapper'
 
 git "/srv/www/app/releases/#{release}" do
   repository app['app_source']['url']
@@ -42,6 +27,11 @@ git "/srv/www/app/releases/#{release}" do
   enable_checkout false
   action :nothing
   notifies :create, 'template[/etc/pm2/conf.d/server.json]', :immediately
+  notifies :run, 'execute[app perms]', :immediately
+  notifies :run, 'execute[set file perms]', :immediately
+  notifies :run, 'execute[npm install]', :immediately
+  notifies :create, 'link[/srv/www/app/current]', :immediately
+  notifies :run, 'execute[pm2]', :immediately
 end
 
 template '/etc/pm2/conf.d/server.json' do
@@ -51,32 +41,27 @@ template '/etc/pm2/conf.d/server.json' do
   mode '0644'
   variables :environments => { 'vars' => env_var }
   action :nothing
-  notifies :run, 'execute[app perms]', :immediately
 end
 
 execute 'app perms' do
   command "chown -R root:root /srv/www/app/releases/#{release}"
   action :nothing
-  notifies :run, 'execute[set file perms]', :immediately
 end
 
 execute 'set file perms' do
   command "setfacl -Rdm g:root:rwx /srv/www/app/releases/#{release}"
   action :nothing
-  notifies :run, 'execute[npm install]', :immediately
 end
 
 execute 'npm install' do
   command "su - root -c 'cd /srv/www/app/releases/#{release} && npm install'"
   action :nothing
-  notifies :create, 'link[/srv/www/app/current]', :immediately
 end
 
 link '/srv/www/app/current' do
   to "/srv/www/app/releases/#{release}"
   link_type :symbolic
   action :nothing
-  notifies :run, 'execute[pm2]', :immediately
 end
 
 execute 'pm2' do

--- a/appserver/recipes/deploy_wrapper.rb
+++ b/appserver/recipes/deploy_wrapper.rb
@@ -1,0 +1,15 @@
+directory '/tmp/.ssh' do
+  owner 'root'
+  group 'root'
+  mode '0770'
+  recursive true
+  action :create
+  notifies :create, 'template[/tmp/.ssh/chef_ssh_deploy_wrapper.sh]', :immediately
+end
+
+template "/tmp/.ssh/chef_ssh_deploy_wrapper.sh" do
+  source "chef_ssh_deploy_wrapper.sh.erb"
+  owner 'root'
+  mode 0770
+  action :nothing
+end


### PR DESCRIPTION
This PR addresses many resource ordering issues. Most resulted around the necessary chaining of dependencies, but not firing if an upstream dependency did not change. I moved all resource notifications to the git resource block and extracted the ssh wrapper to an external recipe.